### PR TITLE
Set minimal git config to allow `git commit` to succeed

### DIFF
--- a/cmd/gokr-amend/amend.go
+++ b/cmd/gokr-amend/amend.go
@@ -131,6 +131,15 @@ func updatePullRequest(ctx context.Context, client *github.Client, owner, repo, 
 		return err
 	}
 
+	// Set dummy values for user.email and user.name. These are not really used because of
+	// `git commit --amend --no-edit`, but `git commit` with fail without them set.
+	if err := git("config", "user.email", "test@example.com"); err != nil {
+		return err
+	}
+	if err := git("config", "user.name", "gokrazy-bot"); err != nil {
+		return err
+	}
+
 	if err := git("commit", "-a", "--amend", "--no-edit"); err != nil {
 		return err
 	}


### PR DESCRIPTION
Ran into an issue in
https://github.com/anupcshan/gokrazy-odroidxu4-kernel/runs/5341641350?check_suite_focus=true

```
2022/02/26 02:10:15 amend.go:83: git [add .]
2022/02/26 02:10:15 amend.go:83: git [commit -a --amend --no-edit]
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az91-455.1u4dveb1r3ruphbftqvtwhitpc.gx.internal.cloudapp.net>) not allowed
2022/02/26 02:10:15 amend.go:174: [git clone --branch=pull-c6ae38b38967a5c33d729c20e508a03ba3e0e3f6 --depth=2
```