### PR TITLE
DRAFT: rebuild-kernel: use native GOARCH for Docker

### DIFF
--- a/cmd/gokr-rebuild-kernel/rebuildkernel.go
+++ b/cmd/gokr-rebuild-kernel/rebuildkernel.go
@@ -14,7 +14,7 @@ import (
 )
 
 const dockerFileContents = `
-FROM debian:bookworm
+FROM --platform=$BUILDPLATFORM debian:bookworm
 
 RUN apt-get update && apt-get install -y \
 {{ if (eq .Cross "arm64") -}}
@@ -22,7 +22,8 @@ RUN apt-get update && apt-get install -y \
 {{ end -}}
   build-essential bc libssl-dev bison flex libelf-dev ncurses-dev ca-certificates zstd kmod python3
 
-COPY gokr-rebuild-kernel /usr/bin/gokr-rebuild-kernel
+ARG BUILDARCH
+COPY gokr-rebuild-kernel.$BUILDARCH /usr/bin/gokr-rebuild-kernel
 COPY config.addendum.txt /usr/src/config.addendum.txt
 {{- range $idx, $path := .Patches }}
 COPY {{ $path }} /usr/src/{{ $path }}
@@ -213,7 +214,7 @@ func rebuildKernel() error {
 
 	dockerBuild := exec.Command(execName,
 		"build",
-		"--platform=linux/amd64",
+		// "--platform=linux/amd64",
 		"--rm=true",
 		"--tag=gokr-rebuild-kernel",
 		".")
@@ -230,7 +231,7 @@ func rebuildKernel() error {
 
 	dockerArgs := []string{
 		"run",
-		"--platform=linux/amd64",
+		// "--platform=linux/amd64",
 		"--volume", abs + ":/tmp/buildresult:Z",
 	}
 


### PR DESCRIPTION
See #7 for context.

When building a kernel inside a containerized Debian, use the native GOARCH version of Debian instead of arm64. This allows to avoid using CPU emulation when building on non-amd64.

Note that this change requires a gokr-rebuild-kernel binary compiled for GOOS=linux named gokr-rebuild-kernel.$GOARCH, so changes in [gokrazy/kernel Makefile](https://github.com/gokrazy/kernel.rpi/blob/main/Makefile#L5) is required:
```console
$  GOOS=linux go build -o gokr-rebuild-kernel.$(go env GOARCH) \
    github.com/gokrazy/autoupdate/cmd/gokr-rebuild-kernel
```

This change is a step to improve compilation speed on non-linux/amd64 platforms such as macOS on Apple Silicon. This will also open the way for building a kernel from Windows.