### PR TITLE
gokr-rebuild-kernel: refactor architecture handling

### DIFF
--- a/cmd/gokr-rebuild-kernel/indocker.go
+++ b/cmd/gokr-rebuild-kernel/indocker.go
@@ -136,7 +136,7 @@ func compile(cross, flavor string) error {
 func indockerMain() {
 	cross := flag.String("cross",
 		"",
-		"if non-empty, cross-compile for the specified arch (one of 'arm64')")
+		"if non-empty, cross-compile for the specified arch (one of 'arm64','amd64')")
 
 	flavor := flag.String("flavor",
 		"vanilla",
@@ -174,10 +174,40 @@ func indockerMain() {
 		log.Fatal(err)
 	}
 
-	if *cross == "arm64" {
-		log.Printf("exporting ARCH=arm64, CROSS_COMPILE=aarch64-linux-gnu-")
-		os.Setenv("ARCH", "arm64")
-		os.Setenv("CROSS_COMPILE", "aarch64-linux-gnu-")
+	// The architecture of the hosting container running the compliation.
+	containerHostArch := runtime.GOARCH
+
+	// Default to building the kernel for the amd64 architecture.
+	// If a cross-compilation target is specified, use that instead.
+	targetArch := "amd64"
+	if *cross != "" {
+		targetArch = *cross
+	}
+
+	if targetArch == containerHostArch {
+		// Native build: container/host arch matches target kernel arch.
+		// Even if cross is set, we will build for the native arch.
+		switch targetArch {
+		case "arm64":
+			log.Printf("exporting ARCH=arm64 (native)")
+			os.Setenv("ARCH", "arm64")
+		case "amd64":
+			log.Printf("exporting ARCH=x86 (native)")
+			os.Setenv("ARCH", "x86")
+		}
+	} else {
+		// container/host arch differs from target kernel arch.
+		// We will build for the target arch using cross-compilation.
+		switch targetArch {
+		case "arm64":
+			log.Printf("exporting ARCH=arm64, CROSS_COMPILE=aarch64-linux-gnu-")
+			os.Setenv("ARCH", "arm64")
+			os.Setenv("CROSS_COMPILE", "aarch64-linux-gnu-")
+		case "amd64":
+			log.Printf("exporting ARCH=x86, CROSS_COMPILE=x86_64-linux-gnu-")
+			os.Setenv("ARCH", "x86")
+			os.Setenv("CROSS_COMPILE", "x86_64-linux-gnu-")
+		}
 	}
 
 	log.Printf("compiling kernel")
@@ -185,7 +215,8 @@ func indockerMain() {
 		log.Fatal(err)
 	}
 
-	if *cross == "arm64" {
+	switch targetArch {
+	case "arm64":
 		if err := copyFile("/tmp/buildresult/vmlinuz", "arch/arm64/boot/Image"); err != nil {
 			log.Fatal(err)
 		}
@@ -235,9 +266,11 @@ func indockerMain() {
 				}
 			}
 		}
-	} else {
+	case "amd64":
 		if err := copyFile("/tmp/buildresult/vmlinuz", "arch/x86/boot/bzImage"); err != nil {
 			log.Fatal(err)
 		}
+	default:
+		log.Fatalf("unsupported target arch: %s", targetArch)
 	}
 }

--- a/cmd/gokr-rebuild-kernel/rebuildkernel.go
+++ b/cmd/gokr-rebuild-kernel/rebuildkernel.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"text/template"
 )
@@ -17,12 +18,12 @@ const dockerFileContents = `
 FROM debian:bookworm
 
 RUN apt-get update && apt-get install -y \
-{{ if (eq .Cross "arm64") -}}
-  crossbuild-essential-arm64 \
+{{ if .CrossPkg -}}
+  {{ .CrossPkg }} \
 {{ end -}}
   build-essential bc libssl-dev bison flex libelf-dev ncurses-dev ca-certificates zstd kmod python3
 
-COPY gokr-rebuild-kernel /usr/bin/gokr-rebuild-kernel
+COPY {{ .ContainerBinary }} /usr/bin/gokr-rebuild-kernel
 COPY config.addendum.txt /usr/src/config.addendum.txt
 {{- range $idx, $path := .Patches }}
 COPY {{ $path }} /usr/src/{{ $path }}
@@ -83,6 +84,90 @@ func find(filename string) (string, error) {
 	return "", fmt.Errorf("could not find file %q", filename)
 }
 
+// findModuleRoot locates the root directory of the main module by inspecting
+// the absolute source-file paths that Go embeds in binaries built without
+// -trimpath (the default for local/development builds). It walks up from the
+// directory of the current source file until it finds a go.mod.
+func findModuleRoot() (string, error) {
+	pc := make([]uintptr, 1)
+	if runtime.Callers(1, pc) == 0 {
+		return "", fmt.Errorf("runtime.Callers returned no frames")
+	}
+	frames := runtime.CallersFrames(pc)
+	f, _ := frames.Next()
+	if f.File == "" || !filepath.IsAbs(f.File) {
+		return "", fmt.Errorf("source path %q is not absolute (binary may have been built with -trimpath)", f.File)
+	}
+	dir := filepath.Dir(f.File)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found walking up from %s", f.File)
+		}
+		dir = parent
+	}
+}
+
+// containerGOOS is the OS of the container image; always linux.
+const containerGOOS = "linux"
+
+// crossPackage returns the Debian package that provides the cross-compilation
+// toolchain when the host arch differs from the target kernel arch.
+// Returns empty string when no cross-compilation is needed.
+func crossPackage(containerArch, targetArch string) string {
+	if containerArch == targetArch {
+		return ""
+	}
+	switch targetArch {
+	case "arm64":
+		return "crossbuild-essential-arm64"
+	case "amd64":
+		return "crossbuild-essential-amd64"
+	default:
+		return ""
+	}
+}
+
+// containerBinaryName returns the filename of the gokr-rebuild-kernel binary
+// that should be copied into the container image. When the host already
+// produces a binary for the container's platform the running executable is
+// used directly; otherwise we cross-compile one first.
+func containerBinaryName(goarch string) (string, error) {
+	if runtime.GOOS == containerGOOS && runtime.GOARCH == goarch {
+		return "gokr-rebuild-kernel", nil
+	}
+
+	linuxBin := "gokr-rebuild-kernel.linux-" + goarch
+
+	moduleRoot, err := findModuleRoot()
+	if err != nil {
+		return "", fmt.Errorf("locating module root for cross-compilation: %v", err)
+	}
+
+	outPath, err := filepath.Abs(linuxBin)
+	if err != nil {
+		return "", err
+	}
+
+	log.Printf("cross-compiling %s/%s container binary from %s", containerGOOS, goarch, moduleRoot)
+	cmd := exec.Command("go", "build", "-o", outPath, "./cmd/gokr-rebuild-kernel")
+	cmd.Dir = moduleRoot
+	cmd.Env = append(os.Environ(),
+		"GOOS="+containerGOOS,
+		"GOARCH="+goarch,
+		"CGO_ENABLED=0",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("cross-compiling %s/%s binary: %v", containerGOOS, goarch, err)
+	}
+	return linuxBin, nil
+}
+
 func getContainerExecutable() (string, error) {
 	// Probe podman first, because the docker binary might actually
 	// be a thin podman wrapper with podman behavior.
@@ -112,7 +197,7 @@ func rebuildKernel() error {
 
 	cross := flag.String("cross",
 		"",
-		"if non-empty, cross-compile for the specified arch (one of 'arm64')")
+		"if non-empty, cross-compile for the specified arch (one of 'arm64','amd64')")
 
 	flavor := flag.String("flavor",
 		"vanilla",
@@ -124,8 +209,8 @@ func rebuildKernel() error {
 
 	flag.Parse()
 
-	if *cross != "" && *cross != "arm64" {
-		return fmt.Errorf("invalid -cross value %q: expected one of 'arm64'")
+	if *cross != "" && *cross != "arm64" && *cross != "amd64" {
+		return fmt.Errorf("invalid -cross value %q: expected one of 'arm64','amd64',''", *cross)
 	}
 
 	abs, err := os.Getwd()
@@ -186,21 +271,53 @@ func rebuildKernel() error {
 		return err
 	}
 
+	// The architecture of the host environment.
+	hostArch := runtime.GOARCH
+
+	// The architecture of the target kernel.
+	var targetArch string
+
+	// Determine the target architecture based on the cross-compilation flag.
+	switch *cross {
+	case "arm64":
+		targetArch = "arm64"
+	case "amd64", "":
+		// Default to building for amd64 if no cross is specified.
+		targetArch = "amd64"
+	default:
+		return fmt.Errorf("invalid -cross value %q: expected one of 'arm64','amd64',''", *cross)
+	}
+
+	// When defining what container platform to compile into, match the host arch for better container performance.
+	// To compile for a target arch that differs from the container arch use cross-compilation.
+	// This should be faster than natively (non-cross) compiling in a container arch that does not match the host arch.
+	containerArch := hostArch
+	containerPlatform := containerGOOS + "/" + containerArch
+
+	crossPkg := crossPackage(containerArch, targetArch)
+
+	containerBin, err := containerBinaryName(containerArch)
+	if err != nil {
+		return err
+	}
+
 	dockerFile, err := os.Create("Dockerfile")
 	if err != nil {
 		return err
 	}
 
 	if err := dockerFileTmpl.Execute(dockerFile, struct {
-		Uid     string
-		Gid     string
-		Patches []string
-		Cross   string
+		Uid             string
+		Gid             string
+		Patches         []string
+		ContainerBinary string
+		CrossPkg        string
 	}{
-		Uid:     u.Uid,
-		Gid:     u.Gid,
-		Patches: patches,
-		Cross:   *cross,
+		Uid:             u.Uid,
+		Gid:             u.Gid,
+		Patches:         patches,
+		ContainerBinary: containerBin,
+		CrossPkg:        crossPkg,
 	}); err != nil {
 		return err
 	}
@@ -213,7 +330,7 @@ func rebuildKernel() error {
 
 	dockerBuild := exec.Command(execName,
 		"build",
-		"--platform=linux/amd64",
+		"--platform="+containerPlatform,
 		"--rm=true",
 		"--tag=gokr-rebuild-kernel",
 		".")
@@ -228,16 +345,25 @@ func rebuildKernel() error {
 
 	var dockerRun *exec.Cmd
 
+	volumeMount := abs + ":/tmp/buildresult"
+	if runtime.GOOS == "linux" {
+		// :Z re-labels the volume for SELinux, only relevant on Linux hosts.
+		volumeMount += ":Z"
+	}
+
 	dockerArgs := []string{
 		"run",
-		"--platform=linux/amd64",
-		"--volume", abs + ":/tmp/buildresult:Z",
+		"--platform=" + containerPlatform,
+		"--volume", volumeMount,
 	}
 
 	if !*keepBuildContainer {
 		dockerArgs = append(dockerArgs, "--rm")
 	}
-	if execName == "podman" {
+	if execName == "podman" && runtime.GOOS == "linux" {
+		// --userns=keep-id maps the in-container user to the host UID via
+		// Linux user namespaces; not applicable on macOS where Podman runs
+		// inside a Linux VM with its own namespace handling.
 		dockerArgs = append(dockerArgs, "--userns=keep-id")
 	}
 	dockerArgs = append(dockerArgs,


### PR DESCRIPTION
This updates the architecture handling in the indocker and rebuildkernel and improves the logic
for cross-compilation by ensuring the best architecture/cross-compilation combo is used when building the kernel.

It also makes the tool work on macos.